### PR TITLE
Automatic update of dependency rfc5424-logging-handler from 1.1.0 to 1.1.2

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f9a5163d4e7039d3392e0029c3d4f29e58f4fb782ebaca7e9fec3418d4eb423a"
+            "sha256": "ddf8f69c66612457278a4a9b8ab0ea1cc74f7cac1ed6b5541d5d61ab71a3765e"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -221,11 +221,11 @@
         },
         "rfc5424-logging-handler": {
             "hashes": [
-                "sha256:34800268ac4a09580b89a3352afc6f3221302b95f5e74a300b14f3d355b28844",
-                "sha256:f9ac979772e7f417b89dae560d9de8741eb97dc31e71068dafa297ea38ea09f2"
+                "sha256:0fa181ba9ef4b517c938c90608f4c3a5c1abf3ea29250f0df294bef439ba2c9e",
+                "sha256:a78a0a42b19e44215cd8a5be4ab42bfd3593c0c30a9cbfde9478e398f502ea00"
             ],
             "index": "pypi",
-            "version": "==1.1.0"
+            "version": "==1.1.2"
         },
         "s3transfer": {
             "hashes": [


### PR DESCRIPTION
Dependency rfc5424-logging-handler was used in version 1.1.0, but the current latest version is 1.1.2.