### PR TITLE
Add InClusterConfigLoader to load SA and cert

### DIFF
--- a/thoth/common/helpers.py
+++ b/thoth/common/helpers.py
@@ -22,6 +22,8 @@ import os
 
 from contextlib import contextmanager
 
+SERVICE_TOKEN_FILENAME = '/var/run/secrets/kubernetes.io/serviceaccount/token'
+SERVICE_CERT_FILENAME = '/var/run/secrets/kubernetes.io/serviceaccount/ca.cert'
 
 @contextmanager
 def cwd(target):
@@ -57,10 +59,24 @@ def datetime_str_from_timestamp(timestamp: int) -> str:
     return datetime2datetime_str(datetime.datetime.fromtimestamp(timestamp))
 
 
+def get_incluster_token_file(token_file=None):
+    if token_file:
+        return token_file
+    else:
+        return SERVICE_TOKEN_FILENAME
+
+
+def get_incluster_ca_file(ca_file=None):
+    if ca_file:
+        return ca_file
+    else:
+        return SERVICE_CERT_FILENAME
+
+
 def get_service_account_token():
     """Get token from service account token file."""
     try:
-        with open('/var/run/secrets/kubernetes.io/serviceaccount/token', 'r') as token_file:
+        with open(get_incluster_token_file(), 'r') as token_file:
             return token_file.read()
     except FileNotFoundError as exc:
         raise FileNotFoundError("Unable to get service account token, please check "


### PR DESCRIPTION
I removed config.load_incluster_config() So that we can pass the files for debugging purpose.

```
 o = OpenShift(openshift_api_url="https://ocp:443",
                  token_file="./token",
                  cert_file="./ca.crt")

    o.get_pod_status(pod_id="podname", namespace="namespace")
```
Here is a test script https://gist.github.com/sub-mod/b101556dda3ab7cb22117a690e9a79ef

```
yum -y install libffi-devel
pip3 install requests pkiutils pyopenssl
```

create token and ca.crt file
```
oc whoami -t > /token
echo QUIT | openssl s_client -showcerts -connect <kubernetes-master-hostname>:8443 2>&1  | openssl x509 -text | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > ca.crt
```
```
import os
from thoth.common import OpenShift
import urllib3

if __name__ == '__main__':
    urllib3.disable_warnings()
    environ = {
        "KUBERNETES_SERVICE_HOST": "OCP",
        "KUBERNETES_SERVICE_PORT": "443",
        "SERVICE_TOKEN_FILENAME": "/./token",
        "SERVICE_CERT_FILENAME": "./ca.crt"
    }
    o = OpenShift(openshift_api_url="https://MS:443",
                  kubernetes_verify_tls=False,
                  token_file="./token",
                  cert_file="./ca.crt",
                  environ=environ)
    state = o.get_pod_status(pod_id="POD", namespace="NS")
    print(state)
```
