### PR TITLE
Add format_datetime method to convert datetimes to default format

### DIFF
--- a/thoth/common/helpers.py
+++ b/thoth/common/helpers.py
@@ -39,6 +39,11 @@ def cwd(target):
         os.chdir(curdir)
 
 
+def get_default_datetime_format():
+    """Return default datetime format string."""
+    return _DATETIME_FORMAT_STRING
+
+
 def parse_datetime(datetime_string: str) -> datetime.datetime:
     """Parse datetime string represented in ISO format."""
     parsed = datetime.datetime.strptime(datetime_string, _DATETIME_FORMAT_STRING)
@@ -47,7 +52,7 @@ def parse_datetime(datetime_string: str) -> datetime.datetime:
 
 
 def format_datetime(dt: datetime.datetime = None) -> str:
-    """Format datetime to default format."""
+    """Return datetime string in default format."""
     # We use strftime to make sure we do not propagate timezone information. We use UTC all over the places.
     return dt.strftime(_DATETIME_FORMAT_STRING)
 

--- a/thoth/common/helpers.py
+++ b/thoth/common/helpers.py
@@ -46,6 +46,12 @@ def parse_datetime(datetime_string: str) -> datetime.datetime:
     return parsed.replace(tzinfo=timezone.utc)
 
 
+def format_datetime(dt: datetime.datetime = None) -> str:
+    """Format datetime to default format."""
+    # We use strftime to make sure we do not propagate timezone information. We use UTC all over the places.
+    return dt.strftime(_DATETIME_FORMAT_STRING)
+
+
 def datetime_str2timestamp(datetime_string: str) -> int:
     """Parse datetime string represented in ISO format and return timestamp."""
     return int(parse_datetime(datetime_string).timestamp())


### PR DESCRIPTION
- prevents from using global default format string when formatting from different
datetime formats

Signed-off-by: Marek Cermak <macermak@redhat.com>

modified:   helpers.py