### PR TITLE
Use 8 random digits in the ID instead of 16

### DIFF
--- a/thoth/common/openshift.py
+++ b/thoth/common/openshift.py
@@ -1144,7 +1144,7 @@ class OpenShift:
     @staticmethod
     def generate_id(prefix: str) -> str:
         """Generate an identifier."""
-        return prefix + "-%016x" % random.getrandbits(64)
+        return prefix + "-%08x" % random.getrandbits(64)
 
     def schedule_dependency_monkey(
         self,


### PR DESCRIPTION
There is a restriction in OpenShift metadata length of 63 digits. With 32 digits already being taken by workflow random digits and inspection random digits, there is not much space left for the inspection identifier.

The same reduction is proposed to be used in the inspection ID.

Signed-off-by: Marek Cermak <macermak@redhat.com>

modified:   thoth/common/openshift.py