### PR TITLE
I had to do it... it was so annoying

### DIFF
--- a/thoth/common/logging.py
+++ b/thoth/common/logging.py
@@ -180,7 +180,7 @@ def init_logging(
     # deployed_to_cluster = bool(int(os.getenv('THOTH_CLUSTER_DEPLOYMENT', '0')))
 
     formatter = daiquiri.formatter.ColorFormatter(
-        fmt="%(asctime)s [%(process)d] %(color)s%(levelname)-8.8s %(name)s:"
+        fmt="%(asctime)s %(process)3d %(color)s%(levelname)-8.8s %(name)s:"
         "%(lineno)d: %(message)s%(color_stop)s"
     )
 


### PR DESCRIPTION
Logs from the cluster:

Before:

```
2020-01-09 14:52:17,583 [1] INFO     thoth.adviser.pipeline_builder:202: Creating pipeline configuration
2020-01-09 14:52:17,604 [90] INFO     thoth.adviser.resolver:397: Resolving direct dependencies
2020-01-09 14:52:43,193 [90] INFO     thoth.adviser.resolver:673: Hold tight, Thoth is computing recommendations for your application...


```

After:

```
2020-01-09 14:52:17,583   1 INFO     thoth.adviser.pipeline_builder:202: Creating pipeline configuration
2020-01-09 14:52:17,604  90 INFO     thoth.adviser.resolver:397: Resolving direct dependencies
2020-01-09 14:52:43,193  90 INFO     thoth.adviser.resolver:673: Hold tight, Thoth is computing recommendations for your application...


```