### PR TITLE
Remove prefix to avoid error in Thoth components

### DIFF
--- a/thoth/common/workflows.py
+++ b/thoth/common/workflows.py
@@ -84,7 +84,7 @@ class Workflow(models.V1alpha1Workflow):  # type: ignore
         """Get Workflow ID."""
         prefix: str = self.name or getattr(self.metadata, "generate_name")
         digest: str = OpenShift.generate_id(prefix)
-        return f"workflow-{digest}"
+        return digest
 
     @property
     def validated(self) -> bool:


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

Remove `workflow-` prefix otherwise components will fail due to constraint in prefix name 
(e.g. `adviser-*` required in adviser id)