### PR TITLE
Migrate method to be used for graph-refresh-job switching to Argo for solvers

### DIFF
--- a/thoth/common/openshift.py
+++ b/thoth/common/openshift.py
@@ -860,20 +860,23 @@ class OpenShift:
             raise ConfigurationError(
                 "Infra namespace is required in order to list solvers"
             )
+        label_selector = "template=solver"
+
         if not self.use_argo:
-            response = self.ocp_client.resources.get(
-                api_version="template.openshift.io/v1", kind="Template", name="templates"
-            ).get(namespace=self.infra_namespace, label_selector="template=solver-workload-operator")
-            _LOGGER.debug(
-                "OpenShift response for getting solver template: %r", response.to_dict()
-            )
-            self._raise_on_invalid_response_size(response)
-            return [
-                obj["metadata"]["labels"]["solver-type"]
-                for obj in response.to_dict()["items"][0]["objects"]
-            ]
-        # TODO: Add method to check for solver type in thoth-infra-namespace
-        return NotImplementedError
+            label_selector = "template=solver-workload-operator"
+
+        response = self.ocp_client.resources.get(
+            api_version="template.openshift.io/v1", kind="Template", name="templates"
+        ).get(namespace=self.infra_namespace, label_selector=label_selector)
+        _LOGGER.debug(
+            "OpenShift response for getting solver template: %r", response.to_dict()
+        )
+        self._raise_on_invalid_response_size(response)
+        return [
+            obj["metadata"]["labels"]["solver-type"]
+            for obj in response.to_dict()["items"][0]["objects"]
+            if "solver-type" in obj["metadata"]["labels"]
+        ]
 
     def schedule_all_solvers(
         self,


### PR DESCRIPTION
Issue encountered running graph-refresh-job with `THOTH_USE_ARGO` =1
```
---> Running application from Python script (app.py) ...
--
  | 2020-02-28 11:14:48,613   1 INFO     thoth.common:259: Setting up logging to a Sentry instance 'sentry.io/1298083', environment 'thoth-psi-stage' and integrations ['SqlalchemyIntegration']
  | 2020-02-28 11:14:48,620   1 INFO     thoth.common:297: Logging to rsyslog endpoint is turned off
  | 2020-02-28 11:14:48,890   1 INFO     alembic.runtime.migration:154: Context impl PostgresqlImpl.
  | 2020-02-28 11:14:48,890   1 INFO     alembic.runtime.migration:161: Will assume transactional DDL.
  | 2020-02-28 11:14:48,939   1 WARNING  thoth.common.openshift:144: TLS verification when communicating with k8s/okd master is disabled
  | 2020-02-28 11:14:48,939   1 INFO     thoth.common.openshift:151: Using Argo Workflow to run jobs
  | 2020-02-28 11:14:48,940   1 INFO     thoth.graph_refresh_job:233: Version v0.6.1+storage.0.22.3.common.0.10.8
  | 2020-02-28 11:14:48,940   1 INFO     thoth.graph_refresh_job:112: Eager stop of scheduling new solver runs for unsolved package versions, packages scheduled: 200
  | 2020-02-28 11:14:49,387   1 CRITICAL root:101: Traceback (most recent call last):
  | File "app.py", line 266, in <module>
  | main()
  | File "app.py", line 238, in main
  | graph_refresh_solver()
  | File "app.py", line 119, in graph_refresh_solver
  | for solver_name in _OPENSHIFT.get_solver_names():
  | TypeError: 'type' object is not iterable
  | Sentry is attempting to send 1 pending error messages
  | Waiting up to 2 seconds
  | Press Ctrl-C to quit
```

Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>