### PR TITLE
Fixes for thamos advise

### DIFF
--- a/thoth/common/openshift.py
+++ b/thoth/common/openshift.py
@@ -1517,7 +1517,7 @@ class OpenShift:
 
         workflow_parameters = self._assign_workflow_parameters_for_ceph()
 
-        _ =  self._schedule_workflow(
+        _ = self._schedule_workflow(
             workflow=self.workflow_manager.submit_adviser_workflow,
             parameters={
                 "template_parameters": template_parameters,

--- a/thoth/common/openshift.py
+++ b/thoth/common/openshift.py
@@ -1517,7 +1517,7 @@ class OpenShift:
 
         workflow_parameters = self._assign_workflow_parameters_for_ceph()
 
-        _ = self._schedule_workflow(
+        self._schedule_workflow(
             workflow=self.workflow_manager.submit_adviser_workflow,
             parameters={
                 "template_parameters": template_parameters,

--- a/thoth/common/openshift.py
+++ b/thoth/common/openshift.py
@@ -1517,7 +1517,7 @@ class OpenShift:
 
         workflow_parameters = self._assign_workflow_parameters_for_ceph()
 
-        return self._schedule_workflow(
+        _ =  self._schedule_workflow(
             workflow=self.workflow_manager.submit_adviser_workflow,
             parameters={
                 "template_parameters": template_parameters,

--- a/thoth/common/openshift.py
+++ b/thoth/common/openshift.py
@@ -2449,14 +2449,14 @@ class OpenShift:
         self, name: str = None, label_selector: str = None, namespace: Optional[str] = None
     ) -> Dict[str, Any]:
         """Get Workflow from a namespace, use one of name or label_selector to identify which one to get."""
-        if not any([name, label_selector]):
-            raise ValueError("One of `name` or `label_selector` has to be provided.")
-        if name and label_selector:
-            raise ValueError("Either `name` or `label_selector` has to be provided.")
-
         wf: Dict[str, Any]
-
         if name:
+            if label_selector is not None:
+                _LOGGER.warning(
+                    "Only one of `name` or `label_selector` can be provided."
+                    f"Ignoring `label_selector={label_selector}`."
+                )
+
             try:
                 response = self.ocp_client.resources.get(
                     api_version="argoproj.io/v1alpha1", kind="Workflow", name="workflows"
@@ -2495,6 +2495,9 @@ class OpenShift:
             self._raise_on_invalid_response_size(response)
 
             wf = response.to_dict()["items"][0]
+
+        else:
+            raise ValueError("Either `name` or `label_selector` has to be provided.")
 
         return wf
 

--- a/thoth/common/openshift.py
+++ b/thoth/common/openshift.py
@@ -2446,36 +2446,64 @@ class OpenShift:
         return jobs_status_count
 
     def get_workflow(
-        self, label_selector: str, namespace: Optional[str] = None
+        self, name: str = None, label_selector: str = None, namespace: Optional[str] = None
     ) -> Dict[str, Any]:
-        """Get Workflow from a namespace, use label_selector to identify which one to get."""
-        try:
-            response = self.ocp_client.resources.get(
-                api_version="argoproj.io/v1alpha1", kind="Workflow", name="workflows"
-            ).get(
-                namespace=namespace or self.infra_namespace, label_selector=label_selector
-            )
-            _LOGGER.debug(
-                "OpenShift response for getting template by label_selector %r: %r",
-                label_selector,
-                response.to_dict(),
-            )
-        except OpenShiftNotFoundError as exc:
-            raise NotFoundException(
-                f"The given Workflow containing label {label_selector} could not be found"
-            ) from exc
+        """Get Workflow from a namespace, use one of name or label_selector to identify which one to get."""
+        if not any([name, label_selector]):
+            raise ValueError("One of `name` or `label_selector` has to be provided.")
+        if name and label_selector:
+            raise ValueError("Either `name` or `label_selector` has to be provided.")
 
-        self._raise_on_invalid_response_size(response)
+        wf: Dict[str, Any]
 
-        wf: Dict[str, Any] = response.to_dict()["items"][0]
+        if name:
+            try:
+                response = self.ocp_client.resources.get(
+                    api_version="argoproj.io/v1alpha1", kind="Workflow", name="workflows"
+                ).get(
+                    namespace=namespace or self.infra_namespace, name=name
+                )
+                _LOGGER.debug(
+                    "OpenShift response for getting template by name %r: %r",
+                    name,
+                    response.to_dict(),
+                )
+            except OpenShiftNotFoundError as exc:
+                raise NotFoundException(
+                    f"The given Workflow {name} could not be found"
+                ) from exc
+
+            wf = response.to_dict()
+
+        elif label_selector:
+            try:
+                response = self.ocp_client.resources.get(
+                    api_version="argoproj.io/v1alpha1", kind="Workflow", name="workflows"
+                ).get(
+                    namespace=namespace or self.infra_namespace, label_selector=label_selector
+                )
+                _LOGGER.debug(
+                    "OpenShift response for getting template by label_selector %r: %r",
+                    label_selector,
+                    response.to_dict(),
+                )
+            except OpenShiftNotFoundError as exc:
+                raise NotFoundException(
+                    f"The given Workflow containing label {label_selector} could not be found"
+                ) from exc
+
+            self._raise_on_invalid_response_size(response)
+
+            wf = response.to_dict()["items"][0]
+
         return wf
 
     def get_workflow_status(
-        self, label_selector: str, namespace: Optional[str] = None
+        self, name: str = None, label_selector: str = None, namespace: Optional[str] = None
     ) -> Dict[str, Any]:
-        """Get a Workflow status, use label_selector to identify which one to get."""
+        """Get a Workflow status, use one of name or label_selector to identify which one to get."""
         wf: Dict[str, Any] = self.get_workflow(
-            label_selector=label_selector, namespace=namespace,
+            name=name, label_selector=label_selector, namespace=namespace,
         )
 
         return wf["status"]

--- a/thoth/common/workflows.py
+++ b/thoth/common/workflows.py
@@ -225,9 +225,6 @@ class WorkflowManager:
 
             wf.spec.arguments.parameters = new_parameters
 
-        # Set the ID to the name that we can track it easily later on
-        wf.metadata.name = wf.id
-
         if not getattr(wf, "validated", True):
             _LOGGER.debug(
                 "The Workflow has not been previously validated."
@@ -244,7 +241,6 @@ class WorkflowManager:
             namespace, body
         )
 
-        # return the computed Workflow ID
         return wf.name
 
     def submit_workflow_from_template(


### PR DESCRIPTION
This commit fixes Workflow ID being reported by thamos instead of the adviser ID and it prevents thamos from failing to wait for an analysis if a Job has not yet been created.