### PR TITLE
make output in solver optional

### DIFF
--- a/thoth/common/openshift.py
+++ b/thoth/common/openshift.py
@@ -793,8 +793,8 @@ class OpenShift:
     def schedule_all_solvers(
         self,
         packages: str,
-        output: str,
         *,
+        output: Optional[str] = None,
         indexes: Optional[List[str]] = None,
         debug: bool = False,
         transitive: bool = False,
@@ -862,9 +862,9 @@ class OpenShift:
     def schedule_solver(
         self,
         packages: str,
-        output: str,
         solver: str,
         *,
+        output: Optional[str] = None,
         indexes: Optional[List[str]] = None,
         debug: bool = False,
         transitive: bool = True,


### PR DESCRIPTION
`output` is not mandatory if we use Argo workflows for solver

Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>