### PR TITLE
move Lazy to common helpers from python helpers

### DIFF
--- a/thoth/common/__init__.py
+++ b/thoth/common/__init__.py
@@ -28,6 +28,7 @@ from .helpers import datetime_str_from_timestamp
 from .helpers import get_service_account_token
 from .helpers import parse_datetime
 from .helpers import timestamp2datetime
+from .helpers import Lazy
 from .json import SafeJSONEncoder
 from .logging import init_logging
 from .openshift import OpenShift
@@ -55,4 +56,5 @@ __all__ = [
     "Workflow",
     "WorkflowManager",
     "timestamp2datetime",
+    "Lazy",
 ]

--- a/thoth/common/helpers.py
+++ b/thoth/common/helpers.py
@@ -26,6 +26,8 @@ from datetime import timezone
 from typing import Generator
 from typing import Optional
 from typing import TypeVar
+from typing import Any
+from typing import Callable
 
 from contextlib import contextmanager
 
@@ -138,3 +140,24 @@ def to_snake_case(obj: T) -> T:
         return aux  # type: ignore
 
     return obj
+
+
+class Lazy(object):
+    """Calculates function exactly once then sets it to be and attribute of object.
+
+    Intended to optimize cases in which a class function is called and does not change
+    after repeated calls. Attribute lookup is ~2x as fast as even the simples function
+    calls.
+    """
+
+    def __init__(self, calculate_function: Callable[..., Any]) -> None:
+        """Create lazy function."""
+        self._calculate = calculate_function
+
+    def __get__(self, obj: object, _: Any = None) -> Any:
+        """Call function and set obj.func_name to value."""
+        if obj is None:
+            return self
+        value = self._calculate(obj)
+        setattr(obj, self._calculate.__name__, value)
+        return value


### PR DESCRIPTION
See https://github.com/thoth-station/python/pull/269

We move `Lazy` from python helpers to here to remove the issue of circular dependencies