### PR TITLE
Rename srcopsmetrics to mi

### DIFF
--- a/thoth/common/openshift.py
+++ b/thoth/common/openshift.py
@@ -1327,16 +1327,16 @@ class OpenShift:
             },
         )
 
-    def schedule_srcopsmetrics_workflow(self, repository: str) -> Optional[str]:
-        """Schedule SrcOpsMetrics Workflow.
+    def schedule_mi_workflow(self, repository: str) -> Optional[str]:
+        """Schedule Meta-information Indicators Workflow.
 
         :param repository:str: GitHub repository in full name format: <repo_owner>/<repo_name>
         """
-        workflow_id = self.generate_id("srcopsmetrics")
+        workflow_id = self.generate_id("mi")
         template_parameters = {"WORKFLOW_ID": workflow_id, "REPOSITORY": repository}
 
         return self._schedule_workflow(
-            workflow=self.workflow_manager.submit_srcopsmetrics,
+            workflow=self.workflow_manager.submit_mi,
             parameters={
                 "template_parameters": template_parameters,
                 "workflow_parameters": {},

--- a/thoth/common/workflows.py
+++ b/thoth/common/workflows.py
@@ -748,12 +748,12 @@ class WorkflowManager:
 
         return workflow_id
 
-    def submit_srcopsmetrics(
+    def submit_mi(
         self,
         template_parameters: Optional[Dict[str, str]] = None,
         workflow_parameters: Optional[Dict[str, Any]] = None,
     ) -> Optional[str]:
-        """Submit SrcOpsMetrics workflow."""
+        """Submit Meta-information Indicators workflow."""
         if not self.openshift.infra_namespace:
             raise ConfigurationError("Infra namespace was not provided.")
 
@@ -765,7 +765,7 @@ class WorkflowManager:
 
         workflow_id: Optional[str] = self.submit_workflow_from_template(
             self.openshift.infra_namespace,
-            label_selector="template=srcopsmetrics",
+            label_selector="template=mi",
             template_parameters=template_parameters,
             workflow_parameters=workflow_parameters,
             workflow_namespace=self.openshift.middletier_namespace,


### PR DESCRIPTION
## Description
Now that the SrcOpsMetrics project is part of thoth and has been renamed to `mi`, everything in common regarding to it should be also renamed. 

## Relevant Issues
This PR fixes https://github.com/thoth-station/mi-scheduler/issues/30