### PR TITLE
Remove IMAGE_STREAM_NAMESPACE env

### DIFF
--- a/thoth/common/openshift.py
+++ b/thoth/common/openshift.py
@@ -1197,7 +1197,6 @@ class OpenShift:
             template_parameters[
                 "THOTH_ADVISER_REQUIREMENTS_LOCKED"
             ] = application_stack["requirements_lock"]
-        template_parameters["IMAGE_STREAM_NAMESPACE"] = self.infra_namespace
         template_parameters["THOTH_ADVISER_JOB_ID"] = adviser_id
         template_parameters["THOTH_ADVISER_DEV"] = "1" if dev else "0"
         template_parameters["THOTH_ADVISER_REQUIREMENTS"] = application_stack[


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

```
2020-08-21 16:14:05,011  27 WARNING  thoth.common.openshift:298: Requested to assign parameter 'IMAGE_STREAM_NAMESPACE' (value 'thoth-infra-stage') to template but template does not provide the given parameter, forcing...
```