### PR TITLE
Provenance checks should be scheduled in backend namespace

### DIFF
--- a/thoth/common/workflows.py
+++ b/thoth/common/workflows.py
@@ -621,7 +621,7 @@ class WorkflowManager:
             label_selector="template=provenance-checker",
             template_parameters=template_parameters,
             workflow_parameters=workflow_parameters,
-            workflow_namespace=self.openshift.middletier_namespace,
+            workflow_namespace=self.openshift.backend_namespace,
         )
 
         return workflow_id


### PR DESCRIPTION
provenance-checks fail as they are scheduled in middletier but the result obtaining logic expects them in backend namespace. They should run in backend namespace all the time.

## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/user-api/issues/1044

## This introduces a breaking change

- [x] No

