### PR TITLE
Add submit and schedule kebechet methods

### DIFF
--- a/thoth/common/openshift.py
+++ b/thoth/common/openshift.py
@@ -1661,10 +1661,6 @@ class OpenShift:
         )
         return (repos, orgs)
 
-    def get_mi_kebechet_repositories(self):
-        """Get all of the repositories that use kebechet."""
-        raise NotImplementedError
-
     @staticmethod
     def parse_cpu_spec(cpu_spec: typing.Optional[str]) -> typing.Optional[float]:
         """Parse the given CPU requirement as used by OpenShift/Kubernetes."""

--- a/thoth/common/openshift.py
+++ b/thoth/common/openshift.py
@@ -1427,6 +1427,24 @@ class OpenShift:
             },
         )
 
+    def schedule_mi_kebechet_workflow(
+        self, repository: str, *, job_id: Optional[str] = None,
+    ) -> Optional[str]:
+        """Schedule Meta-information Indicators Workflow.
+
+        :param repository:str: GitHub repository in full name format: <repo_owner>/<repo_name>
+        """
+        workflow_id = job_id or self.generate_id("mi")
+        template_parameters = {"WORKFLOW_ID": workflow_id, "REPOSITORY": repository}
+
+        return self._schedule_workflow(
+            workflow=self.workflow_manager.submit_mi_kebechet,
+            parameters={
+                "template_parameters": template_parameters,
+                "workflow_parameters": {},
+            },
+        )
+
     def schedule_kebechet_workflow(
         self, webhook_payload: Dict[str, Any], *, job_id: Optional[str] = None,
     ) -> Optional[str]:

--- a/thoth/common/openshift.py
+++ b/thoth/common/openshift.py
@@ -1661,6 +1661,10 @@ class OpenShift:
         )
         return (repos, orgs)
 
+    def get_mi_kebechet_repositories(self):
+        """Get all of the repositories that use kebechet."""
+        raise NotImplementedError
+
     @staticmethod
     def parse_cpu_spec(cpu_spec: typing.Optional[str]) -> typing.Optional[float]:
         """Parse the given CPU requirement as used by OpenShift/Kubernetes."""

--- a/thoth/common/openshift.py
+++ b/thoth/common/openshift.py
@@ -1410,35 +1410,25 @@ class OpenShift:
         )
 
     def schedule_mi_workflow(
-        self, repository: str, *, job_id: Optional[str] = None,
+        self,
+        repository: str,
+        entities: Optional[str] = None,
+        *,
+        job_id: Optional[str] = None,
     ) -> Optional[str]:
         """Schedule Meta-information Indicators Workflow.
 
         :param repository:str: GitHub repository in full name format: <repo_owner>/<repo_name>
         """
         workflow_id = job_id or self.generate_id("mi")
-        template_parameters = {"WORKFLOW_ID": workflow_id, "REPOSITORY": repository}
+        template_parameters = {
+            "WORKFLOW_ID": workflow_id,
+            "REPOSITORY": repository,
+            "ENTITIES": entities,
+        }
 
         return self._schedule_workflow(
             workflow=self.workflow_manager.submit_mi,
-            parameters={
-                "template_parameters": template_parameters,
-                "workflow_parameters": {},
-            },
-        )
-
-    def schedule_mi_kebechet_workflow(
-        self, repository: str, *, job_id: Optional[str] = None,
-    ) -> Optional[str]:
-        """Schedule Meta-information Indicators Workflow.
-
-        :param repository:str: GitHub repository in full name format: <repo_owner>/<repo_name>
-        """
-        workflow_id = job_id or self.generate_id("mi")
-        template_parameters = {"WORKFLOW_ID": workflow_id, "REPOSITORY": repository}
-
-        return self._schedule_workflow(
-            workflow=self.workflow_manager.submit_mi_kebechet,
             parameters={
                 "template_parameters": template_parameters,
                 "workflow_parameters": {},

--- a/thoth/common/openshift.py
+++ b/thoth/common/openshift.py
@@ -1419,6 +1419,8 @@ class OpenShift:
         """Schedule Meta-information Indicators Workflow.
 
         :param repository:str: GitHub repository in full name format: <repo_owner>/<repo_name>
+        :param entities:Optional[str]: Meta-information Indicator Entities that will be inspected
+                                       multiple entities are in form of Foo,Bar,...
         """
         workflow_id = job_id or self.generate_id("mi")
         template_parameters = {

--- a/thoth/common/workflows.py
+++ b/thoth/common/workflows.py
@@ -833,6 +833,31 @@ class WorkflowManager:
 
         return workflow_id
 
+    def submit_mi_kebechet(
+        self,
+        template_parameters: Optional[Dict[str, str]] = None,
+        workflow_parameters: Optional[Dict[str, Any]] = None,
+    ) -> Optional[str]:
+        """Submit Meta-information Indicators inspection of Kebechet workflow."""
+        if not self.openshift.infra_namespace:
+            raise ConfigurationError("Infra namespace was not provided.")
+
+        if not self.openshift.middletier_namespace:
+            raise ConfigurationError("Middletier namespace was not provided.")
+
+        template_parameters = template_parameters or {}
+        workflow_parameters = workflow_parameters or {}
+
+        workflow_id: Optional[str] = self.submit_workflow_from_template(
+            self.openshift.infra_namespace,
+            label_selector="template=mi-kebechet",
+            template_parameters=template_parameters,
+            workflow_parameters=workflow_parameters,
+            workflow_namespace=self.openshift.middletier_namespace,
+        )
+
+        return workflow_id
+
     def submit_build_analysis(
         self,
         template_parameters: Optional[Dict[str, str]] = None,

--- a/thoth/common/workflows.py
+++ b/thoth/common/workflows.py
@@ -833,31 +833,6 @@ class WorkflowManager:
 
         return workflow_id
 
-    def submit_mi_kebechet(
-        self,
-        template_parameters: Optional[Dict[str, str]] = None,
-        workflow_parameters: Optional[Dict[str, Any]] = None,
-    ) -> Optional[str]:
-        """Submit Meta-information Indicators inspection of Kebechet workflow."""
-        if not self.openshift.infra_namespace:
-            raise ConfigurationError("Infra namespace was not provided.")
-
-        if not self.openshift.middletier_namespace:
-            raise ConfigurationError("Middletier namespace was not provided.")
-
-        template_parameters = template_parameters or {}
-        workflow_parameters = workflow_parameters or {}
-
-        workflow_id: Optional[str] = self.submit_workflow_from_template(
-            self.openshift.infra_namespace,
-            label_selector="template=mi-kebechet",
-            template_parameters=template_parameters,
-            workflow_parameters=workflow_parameters,
-            workflow_namespace=self.openshift.middletier_namespace,
-        )
-
-        return workflow_id
-
     def submit_build_analysis(
         self,
         template_parameters: Optional[Dict[str, str]] = None,


### PR DESCRIPTION
## Related Issues and Dependencies
https://github.com/thoth-station/mi-scheduler/pull/58

## This introduces a breaking change

- [ ] Yes
- [X] No

## This Pull Request implements
New submit and schedule methods for MI inspection of Kebechet 

## Description
the `submit_mi` and `schedule_mi_workflow` methods regarding general mi analysis remained untouched
