### PR TITLE
Increase random bits used to distinguish workflows

### DIFF
--- a/thoth/common/openshift.py
+++ b/thoth/common/openshift.py
@@ -1042,12 +1042,12 @@ class OpenShift:
         # name and failed with regexp issues (that were not related to the
         # generateName configuration).
         if prefix and identifier:
-            return ("%s-%s-" + "%08x") % (prefix, identifier, random.getrandbits(32))
+            return ("%s-%s-" + "%08x") % (prefix, identifier, random.getrandbits(128))
 
         if prefix:
-            return prefix + "-%08x" % random.getrandbits(32)
+            return prefix + "-%08x" % random.getrandbits(128)
 
-        return "-%08x" % random.getrandbits(32)
+        return "-%08x" % random.getrandbits(128)
 
     def schedule_dependency_monkey(
         self,


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: #1058 

## This introduces a breaking change

- [x] No

With this change, we will increase the number of bits needed to distinguish documents. 128. With this, we should be able to analyze 2.6×10^10 packages per solver with a probability of  10^(-18) for collision. Kubernetes pod name can hold up to 253 characters, this digest requires 32 characters, argo adds 11 characters to distinguish pods within workflow, cca ~20 is required for solver prefix and the rest is required for delimiters and we still have some free space.

https://en.wikipedia.org/wiki/Birthday_problem#Probability_table