### PR TITLE
Revisit generating id to avoid hash collisions

### DIFF
--- a/thoth/common/openshift.py
+++ b/thoth/common/openshift.py
@@ -18,6 +18,7 @@
 """Handling OpenShift and Kubernetes objects across project."""
 
 import os
+import datetime
 import logging
 import requests
 import typing
@@ -1074,17 +1075,14 @@ class OpenShift:
         prefix: Optional[str] = None, identifier: Optional[str] = None
     ) -> str:
         """Generate an identifier."""
-        # A very first method used 'generatedName' in ImageStream configuration,
-        # but it looks like there is a bug in OpenShift as it did not generated any
-        # name and failed with regexp issues (that were not related to the
-        # generateName configuration).
+        suffix = f"-{datetime.datetime.now():%y%m%d%H%M%S}-{random.getrandbits(64):08x}"
         if prefix and identifier:
-            return ("%s-%s-" + "%08x") % (prefix, identifier, random.getrandbits(128))
+            return f"{prefix}-{identifier}{suffix}"
 
         if prefix:
-            return prefix + "-%08x" % random.getrandbits(128)
+            return f"{prefix}{suffix}"
 
-        return "-%08x" % random.getrandbits(128)
+        return suffix
 
     def schedule_dependency_monkey(
         self,


### PR DESCRIPTION
## Related Issues and Dependencies

With this change, we add datetime to the suffix generated. It will provide the capability to distinguish when the given document was generated just by looking at the document identifier. Another, more important aspect, is that the timestamp encoded will avoid any collisions considering additional suffix. It means that the hash generation in the exact same second would return the same 64 UUID hash, which probability is very close to zero given the random seed.

## This introduces a breaking change

- [x] No
