### PR TITLE
Fix package-extract job id propagation

### DIFF
--- a/thoth/common/openshift.py
+++ b/thoth/common/openshift.py
@@ -1007,12 +1007,12 @@ class OpenShift:
                 "Unknown environment type %r, has to be runtime or buildtime"
             )
 
+        job_id = job_id or self.generate_id("package-extract")
         template_parameters = {
             "THOTH_LOG_PACKAGE_EXTRACT": "DEBUG" if debug else "INFO",
             "THOTH_ANALYZED_IMAGE": image,
             "THOTH_ANALYZER_NO_TLS_VERIFY": int(not verify_tls),
-            "THOTH_PACKAGE_EXTRACT_JOB_ID": job_id
-            or self.generate_id("package-extract"),
+            "THOTH_PACKAGE_EXTRACT_JOB_ID": job_id,
             "THOTH_DOCUMENT_ID": job_id,
             "THOTH_PACKAGE_EXTRACT_METADATA": json.dumps(
                 {


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/thoth-application/issues/848

## This introduces a breaking change

- [x] No

When `job_id` is not supplied, THOTH_DOCUMENT_ID is an empty string.