### PR TITLE
add metadata to relevant schedule methods

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 ---
 repos:
   - repo: git://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.1
+    rev: v1.1.9
     hooks:
       - id: remove-tabs
 
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v2.0.0
+    rev: v3.4.0
     hooks:
       - id: trailing-whitespace
       - id: check-merge-conflict
@@ -23,12 +23,12 @@ repos:
       - id: debug-statements
 
   - repo: git://github.com/pycqa/pydocstyle.git
-    rev: 4.0.1
+    rev: 5.1.1
     hooks:
       - id: pydocstyle
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v3.4.0
     hooks:
       - id: check-toml
       - id: check-yaml
@@ -36,7 +36,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.770
+    rev: v0.800
     hooks:
       - id: mypy
         exclude: '^(docs|tasks|tests)|setup\.py'
@@ -48,7 +48,7 @@ repos:
       - id: black
 
   - repo: https://gitlab.com/PyCQA/flake8
-    rev: '3.7.8'
+    rev: '3.8.4'
     hooks:
       - id: flake8
         additional_dependencies: ['pep8-naming']
@@ -56,6 +56,6 @@ repos:
         args: ['--ignore', 'E2,W5', '--select', 'E,W,F,N', '--max-line-length=120']
 
   - repo: https://github.com/mgedmin/check-manifest
-    rev: '0.39'
+    rev: '0.46'
     hooks:
       - id: check-manifest

--- a/thoth/common/openshift.py
+++ b/thoth/common/openshift.py
@@ -1341,6 +1341,7 @@ class OpenShift:
         github_base_repo_url: Optional[str] = None,
         re_run_adviser_id: Optional[str] = None,
         source_type: Optional[str] = None,
+        kebechet_metadata: Optional[Dict[str, Any]] = None,
     ) -> Optional[str]:
         """Schedule an adviser run."""
         if not self.backend_namespace:
@@ -1397,6 +1398,7 @@ class OpenShift:
                 "origin": origin,
                 "re_run_adviser_id": re_run_adviser_id,
                 "source_type": source_type if source_type is not None else None,
+                "kebechet_metadata": kebechet_metadata,
             }
         )
 
@@ -1436,6 +1438,7 @@ class OpenShift:
         whitelisted_sources: Optional[List[str]] = None,
         debug: bool = False,
         job_id: Optional[str] = None,
+        kebechet_metadata: Optional[Dict[str, Any]] = None,
     ) -> Optional[str]:
         """Run provenance checks on the provided user input."""
         if not self.backend_namespace:
@@ -1452,7 +1455,9 @@ class OpenShift:
         template_parameters = {
             "THOTH_ADVISER_REQUIREMENTS": requirements,
             "THOTH_ADVISER_REQUIREMENTS_LOCKED": requirements_locked,
-            "THOTH_ADVISER_METADATA": json.dumps({"origin": origin}),
+            "THOTH_ADVISER_METADATA": json.dumps(
+                {"origin": origin, "kebechet_metadata": kebechet_metadata}
+            ),
             "THOTH_WHITELISTED_SOURCES": ",".join(whitelisted_sources or []),
             "THOTH_LOG_ADVISER": "DEBUG" if debug else "INFO",
             "THOTH_PROVENANCE_CHECKER_JOB_ID": job_id,
@@ -1588,6 +1593,7 @@ class OpenShift:
         repo_url: str,
         service_name: str = "github",
         *,
+        kebechet_metadata: Optional[Dict[str, Any]] = None,
         job_id: Optional[str] = None,
     ) -> Optional[str]:
         """Schedule Kebechet Workflow for a particular valid slug and service name."""
@@ -1596,6 +1602,7 @@ class OpenShift:
             "WORKFLOW_ID": workflow_id,
             "KEBECHET_REPO_URL": repo_url,
             "KEBECHET_SERVICE_NAME": service_name,
+            "KEBECHET_METADATA": json.dumps(kebechet_metadata),
         }
 
         return self._schedule_workflow(


### PR DESCRIPTION
## Related Issues and Dependencies

thoth-station/kebechet#584

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Add metadata to both kebechet-run-url which is triggered by `kebechet-admin` in workflow helpers as well as `adviser` so that the metadata can be passed when using advise and provenance checkers.  The metadata will be used by kebechet to construct PR and issue bodies. In the case of the advise and provenance manager, the metadata will be sent to adviser and provenance workflows and then be received by kebechet-run-results.