### PR TITLE
run dependency monkey workload on the amun-inspection namespace

### DIFF
--- a/thoth/common/openshift.py
+++ b/thoth/common/openshift.py
@@ -1103,9 +1103,9 @@ class OpenShift:
         limit_latest_versions: Optional[int] = None,
     ) -> Optional[str]:
         """Schedule a dependency monkey run."""
-        if not self.middletier_namespace:
+        if not self.amun_inspection_namespace:
             raise ConfigurationError(
-                "Unable to schedule dependency monkey without middletier namespace being set"
+                "Unable to schedule dependency monkey without amun inspection namespace being set"
             )
 
         job_id = job_id or self.generate_id("dependency-monkey")

--- a/thoth/common/workflows.py
+++ b/thoth/common/workflows.py
@@ -598,8 +598,8 @@ class WorkflowManager:
         if not self.openshift.infra_namespace:
             raise ConfigurationError("Infra namespace was not provided.")
 
-        if not self.openshift.middletier_namespace:
-            raise ConfigurationError("Middletier namespace was not provided.")
+        if not self.openshift.amun_inspection_namespace:
+            raise ConfigurationError("Amun Inspection namespace was not provided.")
 
         template_parameters = template_parameters or {}
         workflow_parameters = workflow_parameters or {}
@@ -609,7 +609,7 @@ class WorkflowManager:
             label_selector="template=dependency-monkey",
             template_parameters=template_parameters,
             workflow_parameters=workflow_parameters,
-            workflow_namespace=self.openshift.middletier_namespace,
+            workflow_namespace=self.openshift.amun_inspection_namespace,
         )
 
         return workflow_id


### PR DESCRIPTION
## Related Issues and Dependencies

Related-to: 
https://github.com/thoth-station/thoth-application/pull/859
https://github.com/thoth-station/thoth-application/issues/629

## This Pull Request implements

run dependency monkey workload on the amun-inspection namespace
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Description

moving dependency moneky execution from middletier to amun-inspection to maximize on the resource consumption.