### PR TITLE
Fix obtaining pod status for workflows

### DIFF
--- a/thoth/common/openshift.py
+++ b/thoth/common/openshift.py
@@ -398,7 +398,7 @@ class OpenShift:
     ) -> Dict[str, Any]:
         """Get status from a task/node in a workflow."""
         pod_id = self.get_workflow_pod_name(node_name, workflow_id, namespace)
-        return self.get_pod_status(pod_id, namespace)
+        return self.get_pod_status_report(pod_id, namespace)
 
     def get_build(self, build_id: str, namespace: str) -> Dict[str, Any]:
         """Get a build in the given namespace."""


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/integration-tests/issues/128

## This introduces a breaking change

- [x] No

## Description

User API schema validation fails as obtaining status of a node in argo workflow does not translate response to the required schema - rather it returns directly Kubernetes low lever pod info which is undesired.
