### PR TITLE
Provide an argument to run authenticated provenance-checks

### DIFF
--- a/thoth/common/openshift.py
+++ b/thoth/common/openshift.py
@@ -1423,6 +1423,7 @@ class OpenShift:
         origin: Optional[str] = None,
         whitelisted_sources: Optional[List[str]] = None,
         debug: bool = False,
+        authenticated: bool = False,
         job_id: Optional[str] = None,
         kebechet_metadata: Optional[Dict[str, Any]] = None,
         justification: Optional[List[Dict[str, Any]]] = None,
@@ -1447,6 +1448,7 @@ class OpenShift:
                     },
                 }
             ),
+            "THOTH_AUTHENTICATED_PROVENANCE_CHECK": "1" if authenticated else "0",
             "THOTH_WHITELISTED_SOURCES": ",".join(whitelisted_sources or []),
             "THOTH_LOG_ADVISER": "DEBUG" if debug else "INFO",
             "THOTH_PROVENANCE_CHECKER_JOB_ID": job_id,


### PR DESCRIPTION
## This introduces a breaking change

- [x] No
