### PR TITLE
Run purge workflows in middletier namespace

### DIFF
--- a/thoth/common/workflows.py
+++ b/thoth/common/workflows.py
@@ -576,14 +576,14 @@ class WorkflowManager:
         if not self.openshift.infra_namespace:
             raise ConfigurationError("Infra namespace was not provided.")
 
-        if not self.openshift.graph_namespace:
-            raise ConfigurationError("Graph namespace was not provided.")
+        if not self.openshift.middletier_namespace:
+            raise ConfigurationError("Middletier namespace was not provided.")
 
         template_parameters = template_parameters or {}
         workflow_parameters = workflow_parameters or {}
 
         workflow_id: Optional[str] = self.submit_workflow_from_template(
-            self.openshift.infra_namespace,
+            self.openshift.middletier_namespace,
             label_selector="template=purge",
             template_parameters=template_parameters,
             workflow_parameters=workflow_parameters,


### PR DESCRIPTION
## Related Issues and Dependencies

We do not have argo workflows in graph namespace, let's utilize middletier namespace. Thanks to @harshad16 for spotting this issue.

## This introduces a breaking change

- [x] No
