### PR TITLE
Add deployment name and component name to knowledge_path

### DIFF
--- a/thoth/common/openshift.py
+++ b/thoth/common/openshift.py
@@ -25,6 +25,7 @@ import typing
 import json
 import random
 import urllib3
+from pathlib import Path
 
 from urllib.parse import urlparse
 
@@ -1528,11 +1529,15 @@ class OpenShift:
                                        multiple entities are in form of Foo,Bar,...
         """
         workflow_id = job_id or self.generate_id("mi")
+
+        deployment_name = os.environ["THOTH_DEPLOYMENT_NAME"]
+        path = Path(deployment_name).joinpath("mi").joinpath(knowledge_path)
+
         template_parameters = {
             "WORKFLOW_ID": workflow_id,
             "REPOSITORY": repository,
             "ENTITIES": entities,
-            "KNOWLEDGE_PATH": knowledge_path,
+            "KNOWLEDGE_PATH": path,
             "MI_THOTH": "1" if mi_used_for_thoth else "0",
             "MI_MERGE": "1" if mi_merge else "0",
         }


### PR DESCRIPTION
## Related Issues and Dependencies
Related to the conversation https://github.com/thoth-station/mi-scheduler/pull/156#discussion_r662184348

## This introduces a breaking change

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements
Everything that will be scheduled from `mi-scheduler` (so any operation related to the `mi` component) will be stored under `s3://thoth/data/{deployment_name}/mi/{application_specific_path}`

