### PR TITLE
Add split for spaces

### DIFF
--- a/thoth/common/openshift.py
+++ b/thoth/common/openshift.py
@@ -1709,7 +1709,7 @@ class OpenShift:
             if repositories is not None and repositories != ""
             else []
         )
-        return (repos, orgs)
+        return ([r.split() for r in repos], [o.split() for o in orgs])
 
     @staticmethod
     def parse_cpu_spec(cpu_spec: typing.Optional[str]) -> typing.Optional[float]:


### PR DESCRIPTION
## Related Issues and Dependencies
the `def get_mi_repositories_and_organizations` was giving back names with spaces around them (id did not strip them from https://github.com/thoth-station/thoth-application/blob/7f48f685731db12fc385a3d8d3bda6437e77b0d6/mi-scheduler/base/configmaps.yaml#L9)
This fixes that

## This introduces a breaking change

- [ ] Yes
- [x] No
