### PR TITLE
Runtime environment entries can have labels associated

### DIFF
--- a/thoth/common/config/runtime_environment.py
+++ b/thoth/common/config/runtime_environment.py
@@ -48,6 +48,7 @@ class RuntimeEnvironment:
     openmpi_version = attr.ib(type=Optional[str], default=None)
     cudnn_version = attr.ib(type=Optional[str], default=None)
     mkl_version = attr.ib(type=Optional[str], default=None)
+    labels = attr.ib(type=Optional[Dict[str, str]], default=None)
     base_image = attr.ib(type=Optional[str], default=None)
     name = attr.ib(type=Optional[str], default=None)
     platform = attr.ib(type=Optional[str], default=None)


### PR DESCRIPTION
## Related Issues and Dependencies

```
2022-01-05 14:12:30,336 [1676235] WARNING  thoth.common.config.runtime_environment: Unknown configuration entry in the configuration file 'labels' with value None
```

## This introduces a breaking change

- [x] No
