### PR TITLE
Fix the send_message assignment with default

### DIFF
--- a/thoth/common/openshift.py
+++ b/thoth/common/openshift.py
@@ -865,7 +865,7 @@ class OpenShift:
         ]
 
         template_parameters["THOTH_SEND_MESSAGES"] = str(
-            int(specification["send_messages"])
+            int(specification.get("send_messages", True))
         )
         template_parameters["THOTH_FORCE_SYNC"] = str(
             int(specification.get("force_sync", False))


### PR DESCRIPTION
Fix the send_message assignment with default
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Description

Related-to: https://github.com/thoth-station/amun-api/issues/641
