### PR TITLE
Update workflows.py

### DIFF
--- a/thoth/common/workflows.py
+++ b/thoth/common/workflows.py
@@ -31,7 +31,7 @@ from typing import Optional
 from typing import Union
 
 from argo.workflows import client
-from argo.workflows import models
+from argo.workflows.client import models
 
 from .exceptions import ConfigurationError
 from .exceptions import WorkflowError


### PR DESCRIPTION
From v4.0.0, [&lowbar;&lowbar;init&lowbar;&lowbar;.py](https://github.com/argoproj-labs/argo-client-python/tree/master/argo/workflows) file of argo-client-python is empty. For this reason, the import should be now:

`from argo.workflows.client import models
`
instead of:

`from argo.workflows import models
`
Other versions of the client (as [this one](https://github.com/CermakM/argo-client-python/tree/master/argo/workflows)) keeps the older content of the  &lowbar;&lowbar;init&lowbar;&lowbar;.py.

The change doesn't produces backward incompatibilities to users with the non-empty version of the &lowbar;&lowbar;init&lowbar;&lowbar;.py





## Related Issues and Dependencies

…

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

… Explain your changes.

## Description

<!--- Describe your changes in detail -->
