### PR TITLE
Make workflows names lowercase [mi-scheduler]

### DIFF
--- a/thoth/common/openshift.py
+++ b/thoth/common/openshift.py
@@ -1523,7 +1523,7 @@ class OpenShift:
         prefixes = []
         if repository:
             # '_' is only allowed character for repository name that is not accepted in workflow name
-            prefixes.append("-".join(repository.replace("_", "-").split("/")))
+            prefixes.append("-".join(repository.lower().replace("_", "-").split("/")))
         if create_knowledge:
             prefixes.append("analysis")
         if mi_merge:


### PR DESCRIPTION
## Related Issues and Dependencies
Related to https://github.com/thoth-station/mi-scheduler/issues/249

## This introduces a breaking change

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Description

In addition to underscores, uppercase letters are also not allowed for workflow names
